### PR TITLE
fix: compress releases for unix with gzip instead of xz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,5 @@ cargo-dist-version = "0.19.1"
 ci = "github"
 installers = []
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+unix-archive = ".tar.gz"
 pr-run-mode = "plan"


### PR DESCRIPTION
It seems like [zed does not support decompressing xz-compressed archives](https://github.com/zed-industries/zed/blob/89fbd6528f688cc98eaa4b3002f4b41da6c7b520/crates/extension/src/wasm_host/wit/since_v0_0_7.rs#L415); and they also seem to have their own gzip decoder (they don't shell out to `gzip`)

To use wakatime-lsp for zed-wakatime, I'd have to either

- contribute TarXZ support to zed's extension WASM host (would take much more time)
- shell out (kinda ugly, might not be cross-platform, might also be slower and/or janky)

So switching to tar.gz tarballs seems like a preferrable option ^^

I just changed the cargo-dist config (see https://opensource.axo.dev/cargo-dist/book/reference/config.html#unix-archive)