### PR TITLE
Added wakatime api-key check in health sub-command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 							println!("wakatime-cli api-key: \u{2705}");
 						} else {
 							println!(
-								"wakatime-cli api-key: \u{274C} (Please add api-key in wakatime config file)"
+								"wakatime-cli api-key: \u{274C} (Please add a valid api-key in wakatime config file)"
 							);
 						}
 					}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 	process::{self, Command},
 };
 use wakatime_ls::LanguageServer;
+mod utils;
 
 const USAGE: &str = concat!(
 	"usage: ",
@@ -23,6 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let _binary = args.next();
 
 	if let Some(arg) = args.next() {
+		println!("{:?}", arg.as_str());
 		match arg.as_str() {
 			"--help" => println!("{USAGE}"),
 			"--version" => println!("{}", env!("CARGO_PKG_VERSION")),
@@ -43,7 +45,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 						eprintln!("could not execute `wakatime-cli`: {err:?}");
 					}
 				}
-				// TODO: add a health check for api key
+
+				match Command::new("wakatime-cli")
+					.arg("--config-read")
+					.arg("api_key")
+					.output()
+				{
+					Ok(output) => {
+						if utils::is_valid_api_key(
+							String::from_utf8_lossy(output.stdout.trim_ascii()).into_owned(),
+						) {
+							println!("wakatime-cli api-key: \u{2705}");
+						} else {
+							println!(
+								"wakatime-cli api-key: \u{274C} (Please add api-key in wakatime config file)"
+							);
+						}
+					}
+					Err(err) if err.kind() == ErrorKind::NotFound => {
+						println!("wakatime-cli: not found in path (wakatime-ls needs it)");
+					}
+					Err(err) => {
+						eprintln!("could not execute `wakatime-cli`: {err:?}");
+					}
+				}
 			}
 			option => {
 				println!("invalid option `{option}` provided\n{USAGE}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let _binary = args.next();
 
 	if let Some(arg) = args.next() {
-		println!("{:?}", arg.as_str());
 		match arg.as_str() {
 			"--help" => println!("{USAGE}"),
 			"--version" => println!("{}", env!("CARGO_PKG_VERSION")),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 // Module for utility functions
 
 pub fn is_valid_api_key(api_key: String) -> bool {
-	api_key.len() == 41 && api_key.starts_with("waka")
+	// api-key format is waka_<uuidv4>
+	api_key.len() == 41 && api_key.starts_with("waka_")
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,22 @@
 // Module for utility functions
 
+/// Validates a wakatime api-key
 pub fn is_valid_api_key(api_key: String) -> bool {
 	// api-key format is waka_<uuidv4>
 	api_key.len() == 41 && api_key.starts_with("waka_")
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn empty_api_key() {
+		assert!(!is_valid_api_key("".to_string()));
+	}
+
+	#[test]
+	fn invalid_format_1() {
+		assert!(!is_valid_api_key("waka_abcd".to_string()));
+	}
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,5 @@
+// Module for utility functions
+
+pub fn is_valid_api_key(api_key: String) -> bool {
+	api_key.len() == 41 && api_key.starts_with("waka")
+}


### PR DESCRIPTION
Running `wakatime-ls --health` will now give info on the status of wakatime api-key

```
wakatime-cli api-key: ✅
```

OR

```
wakatime-cli api-key: ❌ (Please add a valid api-key in wakatime config file)
```